### PR TITLE
Enable preview releases on Cloudflare Pages

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,0 +1,27 @@
+name: Deploy Next.js site to Cloudflare Pages
+
+on: [push]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    environment:
+      name: cloudflare
+      url: ${{steps.deploy.outputs.deployment-url}}
+    name: Publish to Cloudflare Pages
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker://jekyll/jekyll:4.1.0
+        with:
+          entrypoint: /github/workspace/bin/build.sh
+      - name: Publish to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@7a5f8bbdfeedcde38e6777a50fe685f89259d4ca
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: 62758afcaaf5e929beeac70e72312bc6
+          wranglerVersion: "3"
+          command: pages deploy _site --project-name coltonenglish --commit-dirty=true

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Next.js site to Cloudflare Pages
+name: Deploy Jekyll site to Cloudflare Pages
 
 on: [push]
 
@@ -14,7 +14,7 @@ jobs:
     name: Publish to Cloudflare Pages
     steps:
       - uses: actions/checkout@v4
-      - uses: docker://jekyll/jekyll:pages
+      - uses: docker://jekyll/builder:latest
         with:
           entrypoint: /github/workspace/bin/build.sh
       - name: Publish to Cloudflare Pages

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -14,7 +14,7 @@ jobs:
     name: Publish to Cloudflare Pages
     steps:
       - uses: actions/checkout@v4
-      - uses: docker://jekyll/jekyll:4.1.0
+      - uses: docker://jekyll/jekyll:pages
         with:
           entrypoint: /github/workspace/bin/build.sh
       - name: Publish to Cloudflare Pages

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Install dependencies if Gemfile exists
+if [ -f "Gemfile" ]; then
+  bundle install
+fi
+
+# Build the site
+bundle exec jekyll build

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,10 +1,11 @@
-#!/bin/sh
-set -e
+#!/bin/bash
 
-# Install dependencies if Gemfile exists
-if [ -f "Gemfile" ]; then
-  bundle install
+ruby --version
+
+mkdir -p _site .jekyll-cache  # Required due to some file permission issue
+
+if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+  jekyll build
+else
+  jekyll build --drafts $@
 fi
-
-# Build the site
-bundle exec jekyll build

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
+set -e
 
+# Ruby version for debugging
 ruby --version
 
-mkdir -p _site .jekyll-cache  # Required due to some file permission issue
+# Required due to some file permission issue
+mkdir -p _site .jekyll-cache
 
+# Install dependencies if Gemfile exists
+if [ -f "Gemfile" ]; then
+  bundle install
+fi
+
+# Determine if we should build drafts
 if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
-  jekyll build
+  bundle exec jekyll build
 else
-  jekyll build --drafts $@
+  bundle exec jekyll build --drafts
 fi


### PR DESCRIPTION
This change enables preview releases by building the Jekyll site and deploying it to Cloudflare Pages.
It adds a GitHub Action workflow that runs on every push, uses a Jekyll Docker image to build the site via a new `bin/build.sh` script, and then deploys the output to Cloudflare Pages using the `wrangler-action`.

---
*PR created automatically by Jules for task [3818845167289255805](https://jules.google.com/task/3818845167289255805) started by @sparksis*